### PR TITLE
Remove "utf-8" from `.decode()` calls in 009_data tests

### DIFF
--- a/tests/009_data.test.js
+++ b/tests/009_data.test.js
@@ -22,7 +22,7 @@ test("logData logs 3 strings", async () => {
       log_string: (start, length) => {
         const dataView = new Uint8Array(mem.buffer);
         const byteSlice = dataView.slice(start, start + length);
-        loggedStrings.push(new TextDecoder().decode(byteSlice, "utf-8"));
+        loggedStrings.push(new TextDecoder().decode(byteSlice));
       },
     },
   });
@@ -39,7 +39,7 @@ test("logData logs 3 different string(s)", async () => {
       log_string: (start, length) => {
         const dataView = new Uint8Array(mem.buffer);
         const byteSlice = dataView.slice(start, start + length);
-        loggedStrings.push(new TextDecoder().decode(byteSlice, "utf-8"));
+        loggedStrings.push(new TextDecoder().decode(byteSlice));
       },
     },
   });


### PR DESCRIPTION
Fixes https://github.com/EmNudge/watlings/issues/5

Doesn't seem to have been an issue in node, but this is redundant and throws an error in browser contexts.