### PR TITLE
Fix Windows path and patch issues

### DIFF
--- a/exercises/011_host.mjs
+++ b/exercises/011_host.mjs
@@ -8,7 +8,7 @@
 */
 
 import fs from "fs/promises";
-import { getWastParser } from "../utils/getWastParser.mjs";
+import { getWastParser } from "../scripts/utils/getWastParser.mjs";
 
 // parse WAT file to WASM and read it as Buffer
 const wasmBytes = await getWastParser()

--- a/scripts/run.mjs
+++ b/scripts/run.mjs
@@ -3,8 +3,6 @@ import { compileFiles } from './utils/compileFiles.mjs';
 
 const fileNameFilter = process.argv[2];
 
-const exitCode = await compileFiles(fileNameFilter);
-if (exitCode !== 1) {
-  const vitest = await startVitest('test', [fileNameFilter], { watch: false });
-  await vitest?.close();
-}
+await compileFiles(fileNameFilter);
+const vitest = await startVitest('test', [fileNameFilter], { watch: false });
+await vitest?.close();

--- a/scripts/solve.mjs
+++ b/scripts/solve.mjs
@@ -1,11 +1,12 @@
 import { readdir, readFile, writeFile } from 'fs/promises';
 import { basename, extname, } from 'path';
 import { patch } from './utils/patch.mjs';
+import { fileURLToPath } from 'node:url';
 
 // Strip path and extension from argument
 const targetFileName = basename(process.argv[2], extname(process.argv[2]));
 
-const folderFiles = await readdir(new URL('../exercises', import.meta.url));
+const folderFiles = await readdir(fileURLToPath(new URL('../exercises', import.meta.url)));
 const sourceFileNameWithExt = folderFiles.find(fileName => {
   return fileName.includes(targetFileName) && fileName.endsWith('.wat');
 });
@@ -17,13 +18,13 @@ if (!sourceFileNameWithExt) {
 
 const nameBase = basename(sourceFileNameWithExt, '.wat');
 
-const patchFilePath = new URL(`../patch/${nameBase}.patch`, import.meta.url);
+const patchFilePath = fileURLToPath(new URL(`../patch/${nameBase}.patch`, import.meta.url));
 const patchFile = await readFile(patchFilePath, 'utf-8').catch(() => {
   console.error(`No patch file found under patch/${nameBase}.patch`);
   process.exit(1);
 });
 
-const sourceFilePath = new URL(`../exercises/${nameBase}.wat`, import.meta.url);
+const sourceFilePath = fileURLToPath(new URL(`../exercises/${nameBase}.wat`, import.meta.url));
 const sourceFile = await readFile(sourceFilePath, 'utf-8');
 
 try {

--- a/scripts/utils/compileFiles.mjs
+++ b/scripts/utils/compileFiles.mjs
@@ -99,7 +99,8 @@ export async function compileFiles(fileNameFilter = process.argv[2]) {
     const filePath = new URL('../../exercises/' + file, import.meta.url);
     
     try {
-      await parseWast(filePath.pathname);
+      const path = process.arch === 'win32' ? filePath.pathname.slice(1) : filePath.pathname;
+      await parseWast(path);
 
       // add WAT hash
       const fileBytes = await fs.readFile(filePath);

--- a/scripts/utils/compileFiles.mjs
+++ b/scripts/utils/compileFiles.mjs
@@ -99,7 +99,7 @@ export async function compileFiles(fileNameFilter = process.argv[2]) {
     const filePath = new URL('../../exercises/' + file, import.meta.url);
     
     try {
-      const path = process.arch === 'win32' ? filePath.pathname.slice(1) : filePath.pathname;
+      const path = process.platform === 'win32' ? filePath.pathname.slice(1) : filePath.pathname;
       await parseWast(path);
 
       // add WAT hash

--- a/scripts/utils/getWastParser.mjs
+++ b/scripts/utils/getWastParser.mjs
@@ -3,20 +3,20 @@ import fs from 'node:fs/promises';
 import { promisify } from 'node:util';
 import { exec, spawn } from 'node:child_process';
 
-/**
- * @returns {Promise<(filePath: string | URL) => Promise<undefined>>}
- */
-export async function getWastParser() {
-  try {
-    // check if program exists
-    await promisify(exec)('wat2wasm --version');
+/** @typedef {Promise<(filePath: string | URL) => Promise<undefined>>} WastParser */
 
-    return async (filePath) => {
-      const path = new URL(filePath, import.meta.url).pathname;
-      const fileName = path.match(/\/([^\/]+)\.wat$/)[1];
-      const wasmPath = new URL(`../../.cache/${fileName}.wasm`, import.meta.url).pathname;
+/** @returns {WastParser} */
+async function getWat2WasmParser() {
+  // check if program exists
+  await promisify(exec)('wat2wasm --version');
 
-      return new Promise((res, rej) => {
+  return async (filePath) => {
+    const path = new URL(filePath, import.meta.url).pathname;
+    const fileName = path.match(/\/([^\/]+)\.wat$/)[1];
+    const wasmPath = new URL(`../../.cache/${fileName}.wasm`, import.meta.url).pathname;
+
+    try {
+      await new Promise((res, rej) => {
         spawn('wat2wasm', [path, '-o', wasmPath], { stdio:'inherit' })
           .on('close', (err) => {
             if (err !== 1) {
@@ -25,28 +25,42 @@ export async function getWastParser() {
               rej(err);
             }
           });
-      });
+      })
+    } catch {
+      // On Windows, exec might not fail. Fall back to built-in Wabt parser.
+      await (getWabtParser()(filePath));
     }
+  }
+}
+
+/** @returns {WastParser} */
+async function getWabtParser() {
+  const wabt = await Wabt();
+
+  return async (filePath) => {
+    const path = new URL(filePath).pathname;
+    const fileName = path.match(/\/([^\/]+)\.wat$/)[1];
+    const wasmPath = new URL(`../../.cache/${fileName}.wasm`, import.meta.url);
+
+    const fileBytes = await fs.readFile(path);
+
+    const wasmFile = wabt.parseWat('inline', fileBytes, {
+      mutable_globals: true,
+      sat_float_to_int: true,
+      sign_extension: true,
+      bulk_memory: true,
+    });
+
+    const { buffer } = wasmFile.toBinary({ write_debug_names: true });
+    
+    await fs.writeFile(wasmPath, buffer);
+  }
+}
+
+export async function getWastParser() {
+  try {
+    return getWat2WasmParser();
   } catch {
-    const wabt = await Wabt();
-
-    return async (filePath) => {
-      const path = new URL(filePath).pathname;
-      const fileName = path.match(/\/([^\/]+)\.wat$/)[1];
-      const wasmPath = new URL(`../../.cache/${fileName}.wasm`, import.meta.url);
-
-      const fileBytes = await fs.readFile(path);
-
-      const wasmFile = wabt.parseWat('inline', fileBytes, {
-        mutable_globals: true,
-        sat_float_to_int: true,
-        sign_extension: true,
-        bulk_memory: true,
-      });
-
-      const { buffer } = wasmFile.toBinary({ write_debug_names: true });
-      
-      await fs.writeFile(wasmPath, buffer);
-    }
+    return getWabtParser();
   }
 }

--- a/scripts/utils/patch.mjs
+++ b/scripts/utils/patch.mjs
@@ -29,6 +29,12 @@ const PATCH_REGEX = new RegExp(PATCH_REGEX_SOURCE, 'g');
 
 /** @param {string} patchString @param {string} targetString */
 export function patch(patchString, targetString) {
+  // Fix Windows inserting carriage returns
+  if (process.arch === 'win32') {
+    targetString = targetString.replace(/\r/g, '');
+    patchString = patchString.replace(/\r/g, '');
+  }
+
   const targetArr = targetString.split('\n');
 
   for (const match of patchString.matchAll(PATCH_REGEX)) {

--- a/scripts/utils/patch.mjs
+++ b/scripts/utils/patch.mjs
@@ -30,7 +30,7 @@ const PATCH_REGEX = new RegExp(PATCH_REGEX_SOURCE, 'g');
 /** @param {string} patchString @param {string} targetString */
 export function patch(patchString, targetString) {
   // Fix Windows inserting carriage returns
-  if (process.arch === 'win32') {
+  if (process.platform === 'win32') {
     targetString = targetString.replace(/\r/g, '');
     patchString = patchString.replace(/\r/g, '');
   }

--- a/scripts/utils/patch.mjs
+++ b/scripts/utils/patch.mjs
@@ -38,7 +38,6 @@ export function patch(patchString, targetString) {
   const targetArr = targetString.split('\n');
 
   for (const match of patchString.matchAll(PATCH_REGEX)) {
-    /** @type {{ srcRange: string, addLines?: string, delLines?: string }} */
     const { srcRange, addLines, delLines } = match.groups;
 
     if (delLines && !targetString.includes(delLines.replace(/< /g, ''))) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "nodenext",
+    "checkJs": true
+  },
+  "exclude": ["exercises/"]
+}


### PR DESCRIPTION
Final (🤞) portion of https://github.com/EmNudge/watlings/issues/10 (Windows support issue)

Calls to `exec` on windows seem to be using the node modules resolution and were thus picking up on wabt's wat2wasm tool. 

This change started as a fix and then graduated slowly to be a decent refactor. Types in JS files are now backed by a tsconfig file. 

Change overview:
* Strengthen types with tsconfig
* Fix URL paths using `fileURLToPath` (thanks [@iscas-zac](https://github.com/iscas-zac))
* Remove carriage returns when applying patches for windows
* Remove call to `exec` in favor of a `spawn` promise utility