### PR TITLE
Replace example with non-commutative functions

### DIFF
--- a/exercises/002_ordering.wat
+++ b/exercises/002_ordering.wat
@@ -4,20 +4,17 @@
   If we wish we can write WAT like this:
     i32.const 2   ;; push 2_i32 to the stack
     i32.const 18  ;; push 18_i32 to the stack
-    i32.mul       ;; multiply the last 2 numbers and put it back on the stack (36)
+    i32.sub       ;; subtract the last 2 numbers and put it back on the stack (-16)
     i32.const 6   ;; push 6_i32 to the stack
-    i32.add       ;; add the last 2 numbers and put it back on the stack (42)
+    i32.sub       ;; subtract the last 2 numbers and put it back on the stack (-22)
     call $log_num ;; call $log_num with the last number on the stack
 
   For clarity, we can instead write it like
     (call $log_num
-      (i32.add
-        (i32.const 6)
-        (i32.mul (i32.const 18) (i32.const 2))
-      )
+      (i32.sub
+        (i32.sub (i32.const 2) (i32.const 18))
+        (i32.const 6))
     )
-
-  Note that S-expression arguments are provided in the reversed order.
 
   Call log_nums with the arguments (in order) of 1, 2, 3. Try it both ways!
 ;)
@@ -26,7 +23,7 @@
   (import "env" "log" (func $log_nums (param i32) (param i32) (param i32)))
 
   (func $main
-    ;; TODO: call $log_nums here
+      ;; TODO: call $log_nums here
   )
 
   (start $main)

--- a/patch/002_ordering.patch
+++ b/patch/002_ordering.patch
@@ -1,4 +1,4 @@
-29c29
+26c26
 <     ;; TODO: call $log_nums here
 ---
 >     (call $log_nums (i32.const 1) (i32.const 2) (i32.const 3))

--- a/scripts/utils/patch.mjs
+++ b/scripts/utils/patch.mjs
@@ -39,8 +39,7 @@ export function patch(patchString, targetString) {
 
   for (const match of patchString.matchAll(PATCH_REGEX)) {
     const { srcRange, addLines, delLines } = match.groups;
-
-    if (delLines && !targetString.includes(delLines.replace(/< /g, ''))) {
+    if (delLines && !targetString.includes(delLines.slice(1).replace(/< /g, ''))) {
       throw new Error('Patch contains deletion that does not exist in target');
     }
 


### PR DESCRIPTION
I don't think the example is right - if I replace the multiply and add by sub, so that the order of parameters matters, the two examples do not match in their original form (tested by pasting into the 001_hello example file).
This mentions s-expressions having reversed parameters, but I get 1,2,3 logged if I order 1,2,3 top to bottom in the non-expression form, and left to right in the S-expression form