### PR TITLE
Move to wasm-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,13 @@ by fixing a bunch of small programs!
 
 ## Usage
 
-This project uses **[Node 16+]** & **[NPM]** for compilation and testing.
+This project uses **[Node 16+]** & **[wasm-tools]** for compilation and testing.
 
 <br>
-
-Clone the repository and install dependencies with:
 
 ```sh
 git clone git@github.com:EmNudge/watlings.git
 cd watlings
-npm install
 ```
 
 Complete lessons by following the instructions in each exercise within the `exercises` directory.
@@ -63,13 +60,13 @@ We recommend using **[VSCode]** with the **[WATI]** extension.
 This should provide syntax highlighting, intellisense, and other helpful features as you work through the exercises.
 
 
-### Using Wat2Wasm Directly (Recommended)
+### Using wasm-tools CLI
 
-To compile your WAT code, we use **[NPM WABT]**. 
+To compile your WAT code, this project uses the `wasm-tools` CLI.
 
-For syntax highlighting and up-to-date builds, you can **optionally** use the official **[WebAssembly Binary Toolkit][WABT]** which will provide you with a `wat2wasm` CLI tool. If it is found on your path as `wat2wasm`, it will be used instead.
+Install `wasm-tools` and ensure `wasm-tools` is on your PATH. The scripts will invoke `wasm-tools parse` under the hood.
 
-*While it is strictly optional, it can help with debugging.*
+See install instructions: [wasm-tools][wasm-tools]
 
 
 <br>
@@ -122,6 +119,7 @@ When introducing a lot of new syntax, keep the problem scope small, but force th
 [VSCode]: https://code.visualstudio.com
 [WATI]: https://marketplace.visualstudio.com/items?itemName=NateLevin.wati
 [WABT]: https://github.com/WebAssembly/wabt/releases/
+[wasm-tools]: https://github.com/bytecodealliance/wasm-tools
 [Node 16+]: https://nodejs.org/en
 [NPM]: https://www.npmjs.com/
 

--- a/exercises/011_host.mjs
+++ b/exercises/011_host.mjs
@@ -1,7 +1,7 @@
 /*
   We'll need to start talking more about the host environment.
 
-  wat/wast files cannot be directly executed. We're using a parser (wat2wasm) to get the WASM.
+  wat/wast files cannot be directly executed. We're using the wasm-tools CLI (parse) to get the WASM.
   Then we read the file into memory as a Buffer and pass it to WebAssembly.instantiate()
 
   There is nothing you must fix here, but feel free to play around.

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
     "solve": "node scripts/solve.mjs",
     "show": "node scripts/show-solution.mjs"
   },
-  "dependencies": {
-    "wabt": "^1.0.32"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.11.16"
   }

--- a/scripts/utils/getWastParser.mjs
+++ b/scripts/utils/getWastParser.mjs
@@ -1,4 +1,3 @@
-import Wabt from "wabt";
 import fs from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -24,50 +23,28 @@ const spawnPromise = (command, args) => {
 };
 
 /** @returns {WastParser} */
-async function getWat2WasmParser() {
+async function getWasmToolsParser() {
   return async (filePath) => {
     const fileName = basename(filePath, ".wat");
     const wasmPath = fileURLToPath(
       new URL(`../../.cache/${fileName}.wasm`, import.meta.url)
     );
 
-    await spawnPromise("wat2wasm", [filePath, "-o", wasmPath]);
-  };
-}
-
-/** @returns {WastParser} */
-async function getWabtParser() {
-  const wabt = await Wabt();
-
-  return async (filePath) => {
-    const fileName = basename(filePath, ".wat");
-    const wasmPath = fileURLToPath(
-      new URL(`../../.cache/${fileName}.wasm`, import.meta.url)
-    );
-
-    const fileBytes = await fs.readFile(filePath);
-
-    const wasmFile = wabt.parseWat("inline", fileBytes, {
-      mutable_globals: true,
-      sat_float_to_int: true,
-      sign_extension: true,
-      bulk_memory: true,
-    });
-
-    const { buffer } = wasmFile.toBinary({ write_debug_names: true });
-
-    await fs.writeFile(wasmPath, buffer);
+    // Use wasm-tools CLI to parse WAT into a WASM binary
+    await spawnPromise("wasm-tools", ["parse", filePath, "-o", wasmPath]);
   };
 }
 
 export async function getWastParser() {
   try {
-    // check for wat2wasm CLI
-    // Using exec on Windows returns a made up version number
-    await spawnPromise("wat2wasm", ["--version"]);
+    // Check for wasm-tools CLI availability
+    await spawnPromise("wasm-tools", ["--version"]);
 
-    return getWat2WasmParser();
+    return getWasmToolsParser();
   } catch {
-    return getWabtParser();
+    console.error(
+      "wasm-tools CLI not found. Please install it from: https://github.com/bytecodealliance/wasm-tools"
+    );
+    process.exit(1);
   }
 }


### PR DESCRIPTION
Migrates to wasm-tools. 

Was previously using `wabt` which in general is just less user friendly. I could use the [wasm port of wasm-tools](https://www.npmjs.com/package/js-wasm-tools), but it's 2 years old and (I assume) will continue to be out of date.

Downside of the change is that you now need another binary, but this one is rust, so it's already a bit safer than anything off the shelf. 