### PR TITLE
Add CF Pages deployment to web-build CI

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -46,3 +46,66 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-build-dist
+          path: web-build/dist/
+
+  deploy:
+    name: Deploy to Cloudflare Pages
+    needs: check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+    steps:
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build-dist
+          path: dist
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=watlings --branch=${{ github.head_ref || github.ref_name }}
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.deploy.outputs.deployment-url }}';
+            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+            const body = `## 🌐 Preview\n\nDeployed to Cloudflare Pages:\n${url} (\`${sha}\`)`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('## 🌐 Preview')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -3,12 +3,10 @@
 
 # Watlings
 
-Learn the WebAssembly Text Format  
+Learn the WebAssembly Text Format
 by fixing a bunch of small programs!
 
-<br>
-
-[![Button Roadmap]][Roadmap]
+**[Try it in your browser!][Web Version]**
 
 <br>
 
@@ -125,9 +123,7 @@ When introducing a lot of new syntax, keep the problem scope small, but force th
 [Node 23+]: https://nodejs.org/en
 [NPM]: https://www.npmjs.com/
 
-[Roadmap]: https://github.com/users/EmNudge/projects/1
-
-[Button Roadmap]: https://img.shields.io/badge/Roadmap-19A974?style=for-the-badge&logoColor=white&logo=openstreetmap
+[Web Version]: https://watlings.emnudge.dev
 
 [Rustlings]: https://github.com/rust-lang/rustlings
 [ziglings]: https://github.com/ratfactor/ziglings


### PR DESCRIPTION
Add a deploy job to the web-build workflow that uploads the build artifact and deploys it to Cloudflare Pages. Includes automatic preview URL comments on PRs.