### PR TITLE
Add exercises CI workflow to verify patches

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -1,0 +1,29 @@
+name: Exercises CI
+
+on:
+  push:
+    branches: [main]
+    paths: [exercises/**, patch/**, tests/**, scripts/**]
+  pull_request:
+    paths: [exercises/**, patch/**, tests/**, scripts/**]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 23
+
+      - name: Install wasm-tools
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download --repo bytecodealliance/wasm-tools --pattern 'wasm-tools-*-x86_64-linux.tar.gz'
+          tar xzf wasm-tools-*-x86_64-linux.tar.gz
+          echo "$PWD/$(ls -d wasm-tools-*-x86_64-linux)" >> "$GITHUB_PATH"
+
+      - name: Verify exercises fail before patch and pass after
+        run: npm run ci:check

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "start": "node --experimental-wasm-exnref scripts/test.mjs",
     "test": "node --experimental-wasm-exnref scripts/test.mjs",
+    "ci:check": "node --experimental-wasm-exnref scripts/ci-check.mjs",
     "build": "node scripts/build.mjs",
     "solve": "node scripts/solve.mjs",
     "show": "node scripts/show-solution.mjs"

--- a/patch/001_hello.patch
+++ b/patch/001_hello.patch
@@ -1,4 +1,4 @@
-17c17
+19c19
 <     ;; TODO: call $log_num here
 ---
 >     (call $log_num (i32.const 42))

--- a/scripts/ci-check.mjs
+++ b/scripts/ci-check.mjs
@@ -1,0 +1,131 @@
+import { readdir, readFile, writeFile, rm } from "node:fs/promises";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { colors } from "./utils/colors.mjs";
+
+const execFile = promisify(execFileCb);
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const exercisesDir = path.join(rootDir, "exercises");
+const patchDir = path.join(rootDir, "patch");
+
+async function getExercises() {
+  const files = await readdir(exercisesDir);
+  return files
+    .filter((f) => f.endsWith(".wat"))
+    .map((f) => path.basename(f, ".wat"))
+    .sort();
+}
+
+async function isEmptyPatch(name) {
+  const content = await readFile(
+    path.join(patchDir, `${name}.patch`),
+    "utf-8",
+  ).catch(() => "");
+  return content.trim().length === 0;
+}
+
+async function runTest(name) {
+  try {
+    const { stdout } = await execFile(
+      "node",
+      ["--experimental-wasm-exnref", "scripts/test.mjs", name],
+      { cwd: rootDir, timeout: 30_000 },
+    );
+    return { passed: true, output: stdout };
+  } catch (e) {
+    return { passed: false, output: e.stdout ?? "", error: e.stderr ?? "" };
+  }
+}
+
+async function applyPatch(name) {
+  await execFile("node", ["scripts/solve.mjs", name], { cwd: rootDir });
+}
+
+async function backupExercises() {
+  const backup = new Map();
+  const files = await readdir(exercisesDir);
+  for (const file of files) {
+    if (file.endsWith(".wat") || file.endsWith(".mjs")) {
+      backup.set(file, await readFile(path.join(exercisesDir, file), "utf-8"));
+    }
+  }
+  return backup;
+}
+
+async function restoreExercises(backup) {
+  for (const [file, content] of backup) {
+    await writeFile(path.join(exercisesDir, file), content);
+  }
+}
+
+const exercises = await getExercises();
+const backup = await backupExercises();
+const failures = [];
+
+// Clear compilation cache for a clean run
+await rm(path.join(rootDir, ".cache"), { recursive: true, force: true });
+
+try {
+  // Phase 1: unsolved exercises should fail (unless patch is empty)
+  console.log(colors.bold("Phase 1: Verify unsolved exercises fail\n"));
+
+  for (const name of exercises) {
+    const empty = await isEmptyPatch(name);
+    const { passed, output, error } = await runTest(name);
+
+    if (empty) {
+      if (passed) {
+        console.log(`  ${colors.green("✓")} ${name} (no patch needed)`);
+      } else {
+        console.log(
+          `  ${colors.red("✘")} ${name} — expected pass (empty patch) but failed`,
+        );
+        if (error) console.log(`    ${colors.faded(error)}`);
+        failures.push(`${name}: should pass without patch`);
+      }
+    } else {
+      if (!passed) {
+        console.log(`  ${colors.green("✓")} ${name} (correctly fails)`);
+      } else {
+        console.log(
+          `  ${colors.red("✘")} ${name} — should fail before patch but passed`,
+        );
+        failures.push(`${name}: should fail without patch`);
+      }
+    }
+  }
+
+  // Phase 2: apply patches, then all exercises should pass
+  console.log(colors.bold("\nPhase 2: Apply patches and verify all pass\n"));
+
+  for (const name of exercises) {
+    if (!(await isEmptyPatch(name))) await applyPatch(name);
+  }
+
+  // Clear cache so solved exercises get compiled fresh
+  await rm(path.join(rootDir, ".cache"), { recursive: true, force: true });
+
+  for (const name of exercises) {
+    const { passed, error } = await runTest(name);
+    if (passed) {
+      console.log(`  ${colors.green("✓")} ${name}`);
+    } else {
+      console.log(`  ${colors.red("✘")} ${name} — fails after patch`);
+      if (error) console.log(`    ${colors.faded(error)}`);
+      failures.push(`${name}: fails after patch`);
+    }
+  }
+} finally {
+  await restoreExercises(backup);
+}
+
+console.log("\n" + "=".repeat(50));
+if (failures.length) {
+  console.log(`\n${failures.length} failure(s):`);
+  for (const f of failures) console.log(`  - ${f}`);
+  process.exitCode = 1;
+} else {
+  console.log(colors.green("\nAll exercises verified successfully!"));
+}

--- a/tests/utils/test-runner.mjs
+++ b/tests/utils/test-runner.mjs
@@ -31,6 +31,7 @@ const scheduleTestResult = () => {
       console.log(successMessage);
     } else if (failMessage && !isSuccess) {
       console.log(failMessage);
+      process.exitCode = 1;
     }
     testResults.length = 0;
   }, 0);

--- a/web-build/src/confetti.ts
+++ b/web-build/src/confetti.ts
@@ -1,27 +1,10 @@
 import confetti from "canvas-confetti";
 
 export function fireCelebration() {
-  const end = Date.now() + 1500;
-
-  function frame() {
-    confetti({
-      particleCount: 3,
-      angle: 60,
-      spread: 55,
-      origin: { x: 0, y: 0.6 },
-      zIndex: 10000,
-    });
-    confetti({
-      particleCount: 3,
-      angle: 120,
-      spread: 55,
-      origin: { x: 1, y: 0.6 },
-      zIndex: 10000,
-    });
-    if (Date.now() < end) {
-      requestAnimationFrame(frame);
-    }
-  }
-
-  frame();
+  confetti({
+    particleCount: 80,
+    spread: 70,
+    origin: { x: 0.5, y: 0.5 },
+    zIndex: 10000,
+  });
 }


### PR DESCRIPTION
- Add GitHub Actions workflow that runs on exercise/patch/test changes
- New `ci-check.mjs` script verifies exercises fail before patching and pass after
- Fix test runner to set `process.exitCode = 1` on failure
- Simplify confetti animation